### PR TITLE
Fix gnome-shell-extension transaction

### DIFF
--- a/Containerfile.39
+++ b/Containerfile.39
@@ -6,6 +6,8 @@ COPY rootfs/ /
 COPY cosign.pub /etc/pki/containers/
 
 RUN rpm-ostree override remove \
+    gnome-classic-session \
+    gnome-classic-session-xsession \
     gnome-shell-extension-apps-menu \
     gnome-shell-extension-launch-new-instance \
     gnome-shell-extension-places-menu \

--- a/Containerfile.40
+++ b/Containerfile.40
@@ -6,6 +6,8 @@ COPY rootfs/ /
 COPY cosign.pub /etc/pki/containers/
 
 RUN rpm-ostree override remove \
+    gnome-classic-session \
+    gnome-classic-session-xsession \
     gnome-shell-extension-apps-menu \
     gnome-shell-extension-launch-new-instance \
     gnome-shell-extension-places-menu \


### PR DESCRIPTION
gnome-classic-session and gnome-classic-session-xsession must be removed as well to remove shell extensions (dependency chain)