### PR TITLE
Push image by digest instead of by tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,8 +148,6 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.description=${{ github.event.repository.description }}
           tags: |
             type=raw,value=${{ matrix.major_version }},enable=${{ github.event_name != 'pull_request' && matrix.major_version != '' }}
             type=ref,suffix=-${{ matrix.major_version }},event=pr,enable=${{ github.event_name == 'pull_request' }}
@@ -164,7 +162,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create \
+            --annotation "org.opencontainers.image.description=${{ github.event.repository.description }}" \
+            $(jq -cr '.tags | map("--tag " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image


### PR DESCRIPTION
https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners